### PR TITLE
Implements a datastore interface for pluggable persistence mechanisms

### DIFF
--- a/cmd/shortd/main.go
+++ b/cmd/shortd/main.go
@@ -13,11 +13,10 @@ func main() {
 	portFlag := flag.String("port", "8080", "the port we listen to")
 	flag.Parse()
 
-	// temporary to test the logic
-	store.StoreInit()
+	ds, _ := store.NewMemoryDatastore()
 
 	listen := *ipFlag + ":" + *portFlag
-	server := server.NewServer(listen)
+	server := server.NewServer(listen, ds)
 	server.Serve()
 
 }

--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Reader struct {
+	ds store.Datastore
 }
 
-func NewReader() *Reader {
-	return &Reader{}
+func NewReader(ds store.Datastore) *Reader {
+	return &Reader{ds: ds}
 }
 
 func (reader *Reader) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -19,7 +20,12 @@ func (reader *Reader) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	short := req.URL.Path[1:]
 	fmt.Printf("reader: %v\n", short)
 
-	url := store.KV[short]
+	url, err := reader.ds.ReadURL(req.Context(), short)
+	if err != nil {
+		fmt.Printf("not found: %s\n", url)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 	fmt.Printf("url: %s\n", url)
 
 	http.Redirect(w, req, url, http.StatusMovedPermanently)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/nicboul/shortd/internal/reader"
+	"github.com/nicboul/shortd/internal/store"
 	"github.com/nicboul/shortd/internal/writer"
 )
 
@@ -13,14 +14,14 @@ type Server struct {
 	Listen string
 }
 
-func NewServer(listen string) *Server {
+func NewServer(listen string, ds store.Datastore) *Server {
 	server := &Server{
 		Listen: listen,
 		Mux:    mux.NewRouter(),
 	}
 
-	writer := writer.NewWriter()
-	reader := reader.NewReader()
+	writer := writer.NewWriter(ds)
+	reader := reader.NewReader(ds)
 
 	server.Mux.Methods("POST").PathPrefix("/").Handler(writer)
 	server.Mux.Methods("GET").PathPrefix("/").Handler(reader)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,7 +1,41 @@
 package store
 
-var KV map[string]string
+import (
+	"context"
+	"errors"
+)
 
-func StoreInit() {
-	KV = make(map[string]string)
+// A Datastore is a storage mechanism for persisting urls mapping.
+type Datastore interface {
+	ReadURL(ctx context.Context, shortUrl string) (string, error)
+	WriteURL(ctx context.Context, shortUrl, url string) error
+}
+
+type memoryDatastore struct {
+	keyVal map[string]string
+}
+
+var _ Datastore = &memoryDatastore{}
+
+// ErrNotFound is thrown when the given short URL was not found in the datastore.
+var ErrNotFound = errors.New("short url not found in store")
+
+// NewMemoryDatastore instantiates a in-memory datastore.
+func NewMemoryDatastore() (Datastore, error) {
+	return &memoryDatastore{keyVal: make(map[string]string)}, nil
+}
+
+// ReadURL reads the datastore in an attempt to retreive the URL for the provided shortURL.
+func (ds *memoryDatastore) ReadURL(ctx context.Context, shortUrl string) (string, error) {
+	val, ok := ds.keyVal[shortUrl]
+	if !ok {
+		return "", ErrNotFound
+	}
+	return val, nil
+}
+
+// WriteURL writes the datastore to persist the URL keyed with its shorter URL version.
+func (ds *memoryDatastore) WriteURL(ctx context.Context, shortUrl, url string) error {
+	ds.keyVal[shortUrl] = url
+	return nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,55 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nicboul/shortd/internal/store"
+)
+
+func TestMemoryDatastoreWriteURLAndReadURL(t *testing.T) {
+	tests := []struct {
+		name string
+
+		// Read expectations
+		rKey string
+		rVal string
+		rErr error
+
+		// Write expectations
+		wKey string
+		wVal string
+		wErr error
+	}{
+		{
+			name: "no such key",
+			rKey: "foo",
+			rErr: store.ErrNotFound,
+		},
+		{
+			name: "key foo returns value bar",
+			rKey: "foo",
+			rVal: "bar",
+			wKey: "foo",
+			wVal: "bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, _ := store.NewMemoryDatastore()
+
+			if got := ds.WriteURL(context.TODO(), tt.wKey, tt.wVal); got != tt.wErr {
+				t.Fatalf("unexpected write error:\n- want:%+v\n- got:%+v", tt.wErr, got)
+			}
+
+			got, err := ds.ReadURL(context.TODO(), tt.rKey)
+			if err != tt.rErr {
+				t.Fatalf("unexpected read error:\n- want:%+v\n- got:%+v", tt.rErr, err)
+			}
+			if got != tt.rVal {
+				t.Fatalf("unexpected read value:\n- want:%+v\n- got:%+v", tt.rVal, got)
+			}
+		})
+	}
+}

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -11,14 +11,15 @@ import (
 )
 
 type Writer struct {
+	ds store.Datastore
 }
 
 type Url struct {
 	Str string `json:"url"`
 }
 
-func NewWriter() *Writer {
-	return &Writer{}
+func NewWriter(ds store.Datastore) *Writer {
+	return &Writer{ds: ds}
 }
 
 var base66 = []byte{'-', '.', '_', '~',
@@ -70,7 +71,7 @@ func (writer *Writer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	short := base66Convert(h[:3])
 
-	store.KV[short] = url.Str
+	writer.ds.WriteURL(req.Context(), short, url.Str)
 
 	shortUrl := &Url{Str: "http://127.0.0.1:8080/" + short}
 	jsonStr, err := json.Marshal(shortUrl)


### PR DESCRIPTION
For the sake of extending this service to eventually persist the URLs to a database like consul or boltdb, we need a way to plug in the desired mechanism and this PR adds exactly that.

Provided with the PR is the same in-memory key-value storage that was present before.